### PR TITLE
函数名字错误

### DIFF
--- a/source/en/physics/physics/physics-manager.md
+++ b/source/en/physics/physics/physics-manager.md
@@ -30,7 +30,7 @@ cc.director.getPhysicsManager().debugDrawFlags = cc.PhysicsManager.DrawBits.e_aa
 Set the drawing flag to `0` to disable drawing.
 
 ```javascript
-cc.director.getPhysicsManager().DebugDrawFlags = 0;
+cc.director.getPhysicsManager().debugDrawFlags = 0;
 ```
 
 ### Conversion physics units to pixel units


### PR DESCRIPTION
cc.director.getPhysicsManager().DebugDrawFlags = 0;

应为

cc.director.getPhysicsManager().debugDrawFlags = 0;