### PR TITLE
change top bar link for cocos2d-x.org

### DIFF
--- a/en/book.json
+++ b/en/book.json
@@ -10,11 +10,11 @@
                 "links": [
                     {
                         "name": "Manual",
-                        "link": "http://docs.cocos.com/creator/manual/zh"
+                        "link": "http://www.cocos2d-x.org/docs/creator/en/"
                     },
                     {
                         "name": "API",
-                        "link": "http://docs.cocos.com/creator/api/zh"
+                        "link": "http://www.cocos2d-x.org/docs/creator-api/en/"
                     }  
                 ]
             },
@@ -23,11 +23,11 @@
                 "links": [
                     {
                         "name": "Manual",
-                        "link": "http://www.cocos.com/docs/native/"
+                        "link": "http://www.cocos2d-x.org/docs/cocos2d-x/en/"
                     },
                     {
                         "name": "API",
-                        "link": "http://www.cocos.com/docs/native/"
+                        "link": "http://www.cocos2d-x.org/docs/api-ref/cplusplus/v3x/"
                     }
                 ]
             },

--- a/zh/book.json
+++ b/zh/book.json
@@ -10,11 +10,11 @@
                 "links": [
                     {
                         "name": "手册文档",
-                        "link": "http://docs.cocos.com/creator/manual/zh"
+                        "link": "http://www.cocos2d-x.org/docs/creator/zh"
                     },
                     {
                         "name": "API 参考",
-                        "link": "http://docs.cocos.com/creator/api/zh"
+                        "link": "http://www.cocos2d-x.org/docs/creator-api/zh"
                     }  
                 ]
             },
@@ -23,11 +23,11 @@
                 "links": [
                     {
                         "name": "手册文档",
-                        "link": "http://www.cocos.com/docs/native/"
+                        "link": "http://www.cocos2d-x.org/docs/cocos2d-x/zh"
                     },
                     {
                         "name": "API 参考",
-                        "link": "http://www.cocos.com/docs/native/"
+                        "link": "http://www.cocos2d-x.org/docs/api-ref/cplusplus/v3x/"
                     }
                 ]
             },


### PR DESCRIPTION
it seems like master branch was published to `cocos2d-x.org`, because when I test on `cocos2d-x.org` its top bar behavior is the same as `book.json` on master branch.

So, I push PR to master branch, if needed, please modify "cocos2d-x.org" branch's `book.json`