### PR TITLE
use our own chapter expaned plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -7,7 +7,7 @@
         "anchorjs",
         "sharing",
         "splitter",
-        "expandable-chapters-small"
+        "expandable-chapters-small@git+https://github.com/cocos-creator/gitbook-plugin-expandable-chapters-small.git"
     ],
     "styles": {
         "website": "./styles/website.css"


### PR DESCRIPTION
Re:#413

使用之前请一定要执行以下操作：

npm uninstall gitbook-plugin-expandable-chapters-small
gitbook install

插件安装成功之后,在进行 preview 操作