### PR TITLE
更新资源升级指南

### DIFF
--- a/en/release-node/raw-asset-migration.md
+++ b/en/release-node/raw-asset-migration.md
@@ -2,7 +2,6 @@
 
 > This article describes the considerations for migrating the old version Creator project to v1.10 in detail.
   If you have never used an older version, you do not need to read this article.
-> At present, v1.10 is still not officially released, the beta version can be downloaded to [forum post posts](http://forum.cocos.com/t/cocos-creator-v1-10-0-4-10/58534).
 
 In the [Acquire and load asset](../scripting/load-assets.md) document before v1.10, we have mentioned that Creator resources are divided into [Asset](../scripting/load-assets.md#asset) and [RawAsset](../scripting/load-assets.md#raw-asset). At that time this division was mainly to try to reuse the existing Cocos2d-x base modules, and lowering the barriers for Cocos2d-x users. But we still want to replace all the `RawAsset` into the standard `Asset`, with the development of Creator these two years, it is time to do a round of refactoring. Refactoring simplifies the processing of resources by editors and engines, reduces the volume of `settings.js` files after publication, and improves the user's development experience.
 

--- a/zh/release-notes/raw-asset-migration.md
+++ b/zh/release-notes/raw-asset-migration.md
@@ -1,7 +1,6 @@
 # v1.10 资源升级指南
 
 > 本文将详细介绍旧版本 Creator 项目升级到 v1.10 时的注意事项。如果你不是 Creator 旧版本的用户，不需要阅读本文。
-> 目前 v1.10 仍然未正式发布，测试版可到 [论坛发布帖](http://forum.cocos.com/t/cocos-creator-v1-10-0-4-10/58534) 下载
 
 在 v1.10 之前的 [获取和加载资源](../scripting/load-assets.md) 文档中，我们有提到过 Creator 的资源分成了 [Asset](../scripting/load-assets.md#asset) 和 [RawAsset](../scripting/load-assets.md#raw-asset) 两种。当时这样划分主要是为了尽量重用已有的 Cocos2d-x 基础模块，并且降低 Cocos2d-x 用户的上手门槛。不过我们仍一直希望把 RawAsset 全部替换成标准的 Asset，随着 Creator 这两年的发展，是时候进行一轮重构了。重构后可以简化编辑器和引擎对资源的处理方式，减小发布后的 settings.js 文件体积，同时提升用户的开发体验。
 


### PR DESCRIPTION
因为 1.10 已经发布，所以去除文档中关于 1.10 未发布的提示。