### PR TITLE
fix: 修正添加音效的脚本错误

### DIFF
--- a/zh/getting-started/quick-start.md
+++ b/zh/getting-started/quick-start.md
@@ -655,7 +655,7 @@ Star Prefab 需要的设置就完成了，现在从 **层级管理器** 中将 `
         // 跳跃音效资源
         jumpAudio: {
             default: null,
-            type: cc.AudioClip
+            url: cc.AudioClip
         },
     },
 ```
@@ -692,7 +692,7 @@ Star Prefab 需要的设置就完成了，现在从 **层级管理器** 中将 `
         // 得分音效资源
         scoreAudio: {
             default: null,
-            type: cc.AudioClip
+            url: cc.AudioClip
         }
     },
 ```


### PR DESCRIPTION
原文中：
```javascript
        // 跳跃音效资源
        jumpAudio: {
            default: null,
            type: cc.AudioClip
        },
```
使用后，在编辑器内拖拽 mp3 文件到对应区域会报错：

![添加音效脚本报错](http://ww.sinaimg.cx/005zWjpngy1fu0zwffjitj30cd01h742.png)

在浏览器中使用也会报错：

![添加音效脚本报错-2](http://ww.sinaimg.cx/005zWjpngy1fu0zwffer2j30p300z744.jpg)

将 `type` 修改为 `url` 后问题解决：
```javascript
        // 跳跃音效资源
        jumpAudio: {
            default: null,
            url: cc.AudioClip
        },
```