### PR TITLE
webview jsbCallback API method of use changed

### DIFF
--- a/en/components/webview.md
+++ b/en/components/webview.md
@@ -138,21 +138,24 @@ cc.Class({
     properties: {
         webview: cc.WebView
     },
-
-    onLoad: function () {
-        var scheme = "TestKey";// Here are the keywords that are agreed with the internal page
-        var jsCallback = function (url) {
-            // The return value here is the URL value of the internal page, 
-            // and it needs to parse the data it needs
-            var str = url.replace(scheme + '://', '');
-            var data = JSON.stringify(str);
+    // Setting in onLoad will make the callback useless, so we must set the cc.WebView callback in the start cycle.
+    start: function () {
+        // Here are the keywords that are agreed with the internal page
+        // Please set the scheme with lower case, the native won't identify the uppercase char scheme.
+        var scheme = "testkey";
+        var jsCallback = function (target, url) {
+            // The return value here is the URL value of the internal page, and it needs to parse the data it needs.
+            var str = url.replace(scheme + '://', ''); // str === 'a=1&b=2'
+            // webview target
+            console.log(target);
         };
 
         this.webview.setJavascriptInterfaceScheme(scheme);
         this.webview.setOnJSCallback(jsCallback);
     }
 });
-
+```
+```html
 // So when you need to interact with WebView through an internal page, 
 // you should set the internal page URL: TestKey://(the data you want to callback to WebView later)
 // WebView internal page code
@@ -165,7 +168,7 @@ cc.Class({
 <script>
     function onClick () {
         // One of them sets up the URL scheme
-        document.location = 'TestKey://{a: 0, b: 1}';
+        document.location = 'testkey://a=1&b=2';
     }
 </script>
 </html>

--- a/zh/components/webview.md
+++ b/zh/components/webview.md
@@ -135,23 +135,26 @@ cc.Class({
     properties: {
         webview: cc.WebView
     },
+    // onLoad 中设置会导致 API 绑定失效，所以请在 start 中设置 webview 回调。
+    start: function () {
+        // 这里是与内部页面约定的关键字，请不要使用大写字符，会导致 location 无法正确识别。
+        var scheme = "testkey";
 
-    onLoad: function () {
-        var scheme = "TestKey";// 这里是与内部页面约定的关键字
-        function jsCallback (url) {
-            // 这里的返回值是内部页面的 url 数值，
-            // 需要自行解析自己需要的数据
-            var str = url.replace(scheme + '://', '');
-            var data = JSON.stringify(str);// {a: 0, b: 1}
+        function jsCallback (target, url) {
+            // 这里的返回值是内部页面的 url 数值，需要自行解析自己需要的数据。
+            var str = url.replace(scheme + '://', ''); // str === 'a=1&b=2'
+            // webview target
+            console.log(target);
         }
 
         this.webview.setJavascriptInterfaceScheme(scheme);
         this.webview.setOnJSCallback(jsCallback);
     }
 });
-
+```
+```html
 // 因此当你需要通过内部页面交互 WebView 时，
-// 应当设置内部页面 url 为：TestKey://(后面你想要回调到 WebView 的数据) 
+// 应当设置内部页面 url 为：TestKey://(后面你想要回调到 WebView 的数据)
 // WebView 内部页面代码
 <html>
 <body>
@@ -162,7 +165,7 @@ cc.Class({
 <script>
     function onClick () {
         // 其中一个设置URL方案
-        document.location = 'TestKey://{a: 0, b: 1}';
+        document.location = 'testkey://a=1&b=2';
     }
 </script>
 </html>


### PR DESCRIPTION
反馈贴：https://forum.cocos.com/t/topic/71004
相关PR: https://github.com/cocos-creator/cocos2d-x-lite/pull/1535

webview 的 setJSCallback 用法变动较大，论坛里面不少用户在反馈这个手册设置错误，所以修改一下。功能本身没什么问题，只是属性设置，以及 API 的 JSB 绑定时机似乎变更了。
实际效果：
![image](https://user-images.githubusercontent.com/35832931/50157913-9887b700-030d-11e9-881d-722259bacb66.png)
![image](https://user-images.githubusercontent.com/35832931/50157934-ae957780-030d-11e9-8a85-f5a6813ddaf5.png)
![image](https://user-images.githubusercontent.com/35832931/50158048-fcaa7b00-030d-11e9-9981-691984ca17a0.png)

