### PR TITLE
add description for Richtext component additional img attributes

### DIFF
--- a/en/components/richtext.md
+++ b/en/components/richtext.md
@@ -55,8 +55,28 @@ Note: all tag names should be lower case and the property assignment should use 
 | img    |Add image emoji support to your RichText. The emoji name should be a valid spriteframe name in the ImageAtlas property. |`<img src='emoji1' click='handler' />` | Note: Only `<img src='foo' click='bar' />` is a valid img tag. If you specify a large emoji image, it will scale the sprite height to the line height of the RichText together with the sprite width.
 
 
-Tags could be nested, the rules is the same as normal HTML tags. For example, the following settings will render
-a label with font size 30 and color value green.
+#### Optional attribute of img tag (New in v2.3)
+
+For better typography we have provided additional optional attributes for the img tag. You can use `width`,` height` to specify the size of the spriteframe. This will allow the image to be larger or smaller than the line height (but it will not change the line height )
+
+| attribute | Description | Example | Note  |
+| -------- | ----------- | ------- | ------ |
+| height   |Specify the spriteframe height size, the size should be a integer.| `<img src='foo' height=50 />` |If you only assign height the spriteframe will auto keep aspect-ratio
+| width    |Specify the spriteframe width size, the size should be a integer.| `<img src='foo' width=50 />` |You can use both Height and Width `<img src='foo' width=20 height=30 />`
+| offset   |Specify the spriteframe offset in line, the size should be a integer.| `<img src='foo' offset=5,10 />` |Note: Using offset attribute may make your picture overlap with text
+
+In addition, to facilitate more complex typography requirements, we provide the `<img offset />` attribute for the img tag, which will allow you to fine-tune the position of the specified spriteframe in the RichText component.
+
+| position | Example | Description | Note   |
+| -------- | ------- | ----------- | ------ |
+| Y        |`<img src='foo' offset=5 />`|Specify the spriteframe to offset y + 5|If offset only set one Integer value it's will be offset Y
+| Y        |`<img src='foo' offset=-5 />`|Specify the spriteframe to offset y - 5|You can use minus to decrease Y position
+| X, Y     |`<img src='foo' offset=6,5 />`|Specify the spriteframe to offset x + 6 and y + 5|Use `,` to split x and y offset value
+| X, Y     |`<img src='foo' offset=6,-5 />`|Specify the spriteframe to offset x + 6 and y - 5|The offset values should only contains `0-9` and `,` characters
+
+### Nested Tags
+
+Tags could be nested, the rules is the same as normal HTML tags. For example, the following settings will render a label with font size 30 and color value green.
 
 `<size=30><color=green>I'm green</color></size>`
 

--- a/en/components/richtext.md
+++ b/en/components/richtext.md
@@ -58,14 +58,16 @@ Note: all tag names should be lower case and the property assignment should use 
 #### Optional attribute of img tag (New in v2.3)
 
 For better typography we have provided additional optional attributes for the img tag. You can use `width`,` height` to specify the size of the spriteframe. This will allow the image to be larger or smaller than the line height (but it will not change the line height )
+When you change the height or width of the spriteframe, you may need to use the `align` attribute to adjust the alignment of the image in the line.
 
 | attribute | Description | Example | Note   |
 | --------- | ----------- | ------- | ------ |
 | height    | Specify the spriteframe height size, the size should be a integer.| `<img src='foo' height=50 />` | If you only assign height the spriteframe will auto keep aspect-ratio
 | width     | Specify the spriteframe width size, the size should be a integer.| `<img src='foo' width=50 />` | You can use both Height and Width `<img src='foo' width=20 height=30 />`
+| align     | Specify the spriteframe alignment in line, the value should be `bottom`, `top` or `center`.| `<img src='foo' align=center />` | Default spriteframe alignment will be bottom 
 | offset    | Specify the spriteframe offset in line, the size should be a integer.| `<img src='foo' offset=5,10 />` | Using offset attribute may make your picture overlap with text
 
-In addition, to facilitate more complex typography requirements, we provide the `<img offset />` attribute for the img tag, which will allow you to fine-tune the position of the specified spriteframe in the RichText component.
+In addition, to facilitate more complex typography requirements, we provide the `offset` attribute for the img tag, which will allow you to fine-tune the position of the specified spriteframe in the RichText component.
 
 | position | Example | Description | Note   |
 | -------- | ------- | ----------- | ------ |

--- a/en/components/richtext.md
+++ b/en/components/richtext.md
@@ -51,28 +51,28 @@ Note: all tag names should be lower case and the property assignment should use 
 | u      |Add a underline to the text|`<u>This text will have a underline</u>`| The tag name must be lowercase and tag name `underline` is not supported.
 | on     |Specify a event callback to a text node，when you click the node，the callback will be triggered.| `<on click="handler"> click me! </on>` | Every valid tag could also add another click event attribute. eg. `<size=10 click="handler2">click me</size>`
 | param  |When the click event is triggered, the value can be obtained in the second parameter of the callback function.| `<on click="handler" param="test"> click me! </on>`|Depends on the click event|
-| br     |Insert a empty line| `<br/>`| Note：`<br></br>` and `<br>` are both invalid tags.
-| img    |Add image emoji support to your RichText. The emoji name should be a valid spriteframe name in the ImageAtlas property. |`<img src='emoji1' click='handler' />` | Note: Only `<img src='foo' click='bar' />` is a valid img tag. If you specify a large emoji image, it will scale the sprite height to the line height of the RichText together with the sprite width.
+| br     |Insert a empty line| `<br/>`|`<br></br>` and `<br>` are both invalid tags.
+| img    |Add image emoji support to your RichText. The emoji name should be a valid spriteframe name in the ImageAtlas property. |`<img src='emoji1' click='handler' />` | Only `<img src='foo' click='bar' />` is a valid img tag. If you specify a large emoji image, it will scale the sprite height to the line height of the RichText together with the sprite width.
 
 
 #### Optional attribute of img tag (New in v2.3)
 
 For better typography we have provided additional optional attributes for the img tag. You can use `width`,` height` to specify the size of the spriteframe. This will allow the image to be larger or smaller than the line height (but it will not change the line height )
 
-| attribute | Description | Example | Note  |
-| -------- | ----------- | ------- | ------ |
-| height   |Specify the spriteframe height size, the size should be a integer.| `<img src='foo' height=50 />` |If you only assign height the spriteframe will auto keep aspect-ratio
-| width    |Specify the spriteframe width size, the size should be a integer.| `<img src='foo' width=50 />` |You can use both Height and Width `<img src='foo' width=20 height=30 />`
-| offset   |Specify the spriteframe offset in line, the size should be a integer.| `<img src='foo' offset=5,10 />` |Note: Using offset attribute may make your picture overlap with text
+| attribute | Description | Example | Note   |
+| --------- | ----------- | ------- | ------ |
+| height    | Specify the spriteframe height size, the size should be a integer.| `<img src='foo' height=50 />` | If you only assign height the spriteframe will auto keep aspect-ratio
+| width     | Specify the spriteframe width size, the size should be a integer.| `<img src='foo' width=50 />` | You can use both Height and Width `<img src='foo' width=20 height=30 />`
+| offset    | Specify the spriteframe offset in line, the size should be a integer.| `<img src='foo' offset=5,10 />` | Using offset attribute may make your picture overlap with text
 
 In addition, to facilitate more complex typography requirements, we provide the `<img offset />` attribute for the img tag, which will allow you to fine-tune the position of the specified spriteframe in the RichText component.
 
 | position | Example | Description | Note   |
 | -------- | ------- | ----------- | ------ |
-| Y        |`<img src='foo' offset=5 />`|Specify the spriteframe to offset y + 5|If offset only set one Integer value it's will be offset Y
-| Y        |`<img src='foo' offset=-5 />`|Specify the spriteframe to offset y - 5|You can use minus to decrease Y position
-| X, Y     |`<img src='foo' offset=6,5 />`|Specify the spriteframe to offset x + 6 and y + 5|Use `,` to split x and y offset value
-| X, Y     |`<img src='foo' offset=6,-5 />`|Specify the spriteframe to offset x + 6 and y - 5|The offset values should only contains `0-9` and `,` characters
+| Y        | `<img src='foo' offset=5 />`| Specify the spriteframe to offset y + 5| If offset only set one Integer value it's will be offset Y
+| Y        | `<img src='foo' offset=-5 />`| Specify the spriteframe to offset y - 5| You can use minus to decrease Y position
+| X, Y     | `<img src='foo' offset=6,5 />`| Specify the spriteframe to offset x + 6 and y + 5| Use `,` to split x and y offset value
+| X, Y     | `<img src='foo' offset=6,-5 />`| Specify the spriteframe to offset x + 6 and y - 5| The offset values should only contains `0-9` and `-,` characters
 
 ### Nested Tags
 

--- a/zh/components/richtext.md
+++ b/zh/components/richtext.md
@@ -58,13 +58,15 @@ RichText 组件用来显示一段带有不同样式效果的文字，你可以�
 
 #### img标签的可选属性
 
-为了更好的排版，我们为img标签类型提供了可选属性，你可以使用width及height来指定spriteframe的大小，这将允许该图片可以大于或是小于行高 (但此设定不会改变行高)
+为了更好的排版，我们为img标签类型提供了可选属性，你可以使用`width`及`height`来指定spriteframe的大小，这将允许该图片可以大于或是小于行高 (但此设定不会改变行高)
+当你改变了spriteframe的高度或宽度后，你或许会需要使用`align`来调整该图片在行中的对齐方式。
 
 | 属性       | 描述        | 示例     | 注意事项  |
 | --------- | ----------- | ------- | -------- |
 | height    | 指定spriteframe的渲染高度，大小值必须为整数 | `<img src='foo' height=50 />` | 如果你只使用高度属性，该spriteframe会自动计算宽度以保持图片比例
 | width     | 指定spriteframe的渲染宽度，大小值必须为整数 | `<img src='foo' width=50 />` | 你可以同时使用高度及宽度属性 `<img src='foo' width=20 height=30 />`
-| offset    | 指定spriteframe的偏移位置，小小值必需为整数 | `<img src='foo' offset=5,10 />` | 使用偏移属性可能会令图片与文字交错，请小心使用
+| align     | 指定spriteframe在行中的对齐方式，值必需为 `bottom`、`top`或`center`.| `<img src='foo' align=center />` | 预设对齐方式为bottom
+| offset    | 指定spriteframe的偏移位置，大小值必需为整数 | `<img src='foo' offset=5,10 />` | 使用偏移属性可能会令图片与文字交错，请小心使用
 
 为了一些更为复杂的排版需求，我们提供了额外的`offset`属性，它允许你微调spriteframe在Richtext中的位置
 

--- a/zh/components/richtext.md
+++ b/zh/components/richtext.md
@@ -56,6 +56,28 @@ RichText 组件用来显示一段带有不同样式效果的文字，你可以�
 | img     | 给富文本添加图文混排功能，img 的 src 属性必须是 ImageAtlas  图集里面的一个有效的 spriteframe 名称 |`<img src='emoji1' click='handler' />` | 注意: 只有 `<img src='foo' click='bar' />` 这种写法是有效的。如果你指定一张很大的图片，那么该图片创建出来的精灵会被等比缩放，缩放的值等于富文本的行高除以精灵的高度。
 
 
+#### img标签的可选属性
+
+为了更好的排版，我们为img标签类型提供了可选属性，你可以使用width及height来指定spriteframe的大小，这将允许该图片可以大于或是小于行高 (但此设定不会改变行高)
+
+| 属性       | 描述        | 示例     | 注意事项  |
+| --------- | ----------- | ------- | -------- |
+| height    | 指定spriteframe的渲染高度，大小值必须为整数 | `<img src='foo' height=50 />` | 如果你只使用高度属性，该spriteframe会自动计算宽度以保持图片比例
+| width     | 指定spriteframe的渲染宽度，大小值必须为整数 | `<img src='foo' width=50 />` | 你可以同时使用高度及宽度属性 `<img src='foo' width=20 height=30 />`
+| offset    | 指定spriteframe的偏移位置，小小值必需为整数 | `<img src='foo' offset=5,10 />` | 使用偏移属性可能会令图片与文字交错，请小心使用
+
+为了一些更为复杂的排版需求，我们提供了额外的`offset`属性，它允许你微调spriteframe在Richtext中的位置
+
+| position | Example | Description | Note   |
+| -------- | ------- | ----------- | ------ |
+| Y        | `<img src='foo' offset=5 />`| 指定spriteframe的y轴加上5 | 当offset只设定一个值的时候，它代表y轴的偏移
+| Y        | `<img src='foo' offset=-5 />`| 指定spriteframe的y轴减少5 | 你可以设定负整数来减少y轴
+| X, Y     | `<img src='foo' offset=6,5 />`| 指定spriteframe的x轴加上6，y轴加上5 | 使用 `,` 号以分隔x轴及y轴偏移值
+| X, Y     | `<img src='foo' offset=6,-5 />`| 指定spriteframe的x轴加上6，y轴减少5 | 偏移属性的值只能包含 `0-9` 及 `-,` 等字元
+
+
+### 标签嵌套
+
 标签与标签是支持嵌套的，且嵌套规则跟 HTML 是一样的。比如下面的嵌套标签设置一个文本的渲染大小为 30，且颜色为绿色。
 
 `<size=30><color=green>I'm green</color></size>`


### PR DESCRIPTION
新增Richtext组件中 `<img />`的额外attribute使用说明
关联PR: https://github.com/cocos-creator/engine/pull/6017

因为不确定怎么样的排版可以，暂时先写一版让你们review一下