### PR TITLE
替换 cocos2d-x-lite 引擎链接

### DIFF
--- a/en/advanced-topics/engine-customization.md
+++ b/en/advanced-topics/engine-customization.md
@@ -2,24 +2,21 @@
 
 The game engine in Cocos Creator has two parts: JavaScript engine with ECS (entity-component system) and C++ (custom version of Cocos2d-x). They are both open sourced on GitHub:
 
-- Creator-JS engine: https://github.com/cocos-creator/engine
-- Cocos2d-x-lite engine：https://github.com/cocos-creator/cocos2d-x-lite
+- [Creator-JS engine](https://github.com/cocos-creator/engine)
+- [Cocos2d-x-lite engine](https://github.com/cocos-creator/engine-native)
 
-If you want to customize engine, we recommend that you follow the __fork workflow__ thru GitHub. 
-Please read [GitHub help: Fork A Repo](https://help.github.com/articles/fork-a-repo) to learn the details.
+If you want to customize engine, we recommend that you follow the __fork workflow__ thru GitHub. Please read [GitHub help: Fork A Repo](https://help.github.com/articles/fork-a-repo) to learn the details.
 
 ## Customize JavaScript Engine
 
-If your concern is only Web based games, or what you want to change in the engine is not native API 
-related (for example UI and animation components), you just need to follow the workflow here:
+If your concern is only Web based games, or what you want to change in the engine is not native API related (for example UI and animation components), you just need to follow the workflow here:
 
 ### Get JavaScript Engine Repository
-First, you need to clone the engine repository or fork the repo. You have to make sure the repo is 
-at the corresponding branch. For example to customize engine for __Cocos Creator v1.1.2__ you'd need 
-to checkout `v1.1` branch; for __Cocos Creator v1.2.1__ you'd need to checkout `v1.2` branch. 
-Once cloning is completed, go to the repo's folder in command-line shell.
+
+First, you need to clone the engine repository or fork the repo. You have to make sure the repo is at the corresponding branch. For example to customize engine for __Cocos Creator v1.1.2__ you'd need to checkout `v1.1` branch; for __Cocos Creator v1.2.1__ you'd need to checkout `v1.2` branch. Once cloning is completed, go to the repo's folder in command-line shell.
 
 ### Install NPM Dependencies
+
 __npm__ and __gulp__ are core components for engine building. These need to be installed. Example:
 
 ```bash
@@ -28,6 +25,7 @@ npm install
 ```
 
 ### Change and Build
+
 Now you can do whatever you want to the engine, once you finished:
 
 ```bash
@@ -41,10 +39,9 @@ This will generated a compiled engine to `bin` folder.
 
 Goto **Preferences** panel and click [Native Develop Tab](../getting-started/basics/editor-panels/preferences.md#--8). And follow the guide to set the path to your customized JavaScript engine.
 
-
 ## Customized Cocos2d-x C++ Engine
 
-If you need to change stuff of rendering or native API related function. Besides updating JavaScript engine (so that your change can work with component system) you'll need to synchronize your change to the customized cocos2d-x-lite engine of Cocos Creator. Please make sure you get the cocos2d-x-lite engine repo from the link on top of this article, it's not the same as the stand alone cocos2d-x repo (http://github.com/cocos2d/cocos2d-x)!
+If you need to change stuff of rendering or native API related function. Besides updating JavaScript engine (so that your change can work with component system) you'll need to synchronize your change to the customized cocos2d-x-lite engine of Cocos Creator. Please make sure you get the cocos2d-x-lite engine repo from the link on top of this article, it's not the same as the stand alone [cocos2d-x repo](http://github.com/cocos2d/cocos2d-x)!
 
 Same as JavaScript engine, you need to make sure cocos2d-x-lite repo is on correct branch. For Cocos Creator v1.2.0 please checkout `v1.2` branch.
 
@@ -61,21 +58,17 @@ python download-deps.py
 git submodule update --init
 ```
 
-
 ### Used customized cocos2d-x-lite engine in Cocos Creator
 
 Goto **Preferences** panel and click [Native Develop Tab](../getting-started/basics/editor-panels/preferences.md#--8). And follow the guide to set the path to your customized cocos2d-x-lite engine.
 
 ### Build from Source
 
-Next, you can start working on updating code for Cocos2d-x-lite. If you want to use source code in your 
-built project you can just choose `default` template in **Build** panel and compile from the source, no 
-extra command line work needed.
+Next, you can start working on updating code for Cocos2d-x-lite. If you want to use source code in your built project you can just choose `default` template in **Build** panel and compile from the source, no extra command line work needed.
 
 ### Build binary library and simulator
 
-If you want to use a `binary` template to build and compile native project (it's much faster since C++ 
-code are already compiled), you'll need to run these commands:
+If you want to use a `binary` template to build and compile native project (it's much faster since C++ code are already compiled), you'll need to run these commands:
 
 ```bash
 # use cocos console to generate prebuilt binary libs
@@ -91,8 +84,7 @@ gulp gen-simulator
 gulp update-simulator-config
 ```
 
-`gulp sign-simulator` is a new command since 1.7.0. Only Mac need to run it. See [Build simulator](https://github.com/cocos-creator/cocos2d-x-lite/blob/develop/README.md#git-user-attention) for details.
-
+`gulp sign-simulator` is a new command since 1.7.0. Only Mac need to run it. See [Build simulator](https://github.com/cocos-creator/engine-native/blob/develop/README.md#git-user-attention) for details.
 
 ### JSB Workflow (JavaScript Binding)
 

--- a/en/getting-started/basics/editor-panels/preferences.md
+++ b/en/getting-started/basics/editor-panels/preferences.md
@@ -26,7 +26,6 @@ This item is selected, Build log will be displayed directly in the process of pu
 Non-selected, Building the release of primary logs are saved in the `%USER/.CocosCreator/logs/native.log` project,
 you can also use the **Console** Log button in the upper left corner of the panel **Cocos Console Log** option to open the document.
 
-
 ### Spin step
 
 In the **Properties**, all numeric property has a set of UP and DOWN arrows next to the input box,
@@ -52,9 +51,7 @@ This category is used to set the default open mode for scripts and resources.
 ### <a name="script-editor"></a>External Script Editor
 
 You can use built-in Code Editor or any external text tool executable file, as in **Assets** opens when you double-click
-a script file. Also available in the drop-down menu select **Internal**,
-or click **Browse** button select the executable file of the preferred text editor.
-
+a script file. Also available in the drop-down menu select **Internal**, or click **Browse** button select the executable file of the preferred text editor.
 
 ### External Picture Editor
 
@@ -76,20 +73,17 @@ declarations and other built-in components engine module in the Web environment.
 
 ### JavaScript Engine Path
 
-In addition to using `engine`, you can also customize to https://github.com/cocos-creator/engine to clone or
-fork a copy of the engine to the local anywhere,
-then uncheck **Use Builtin JavaScript Engine** and set the **Use Builtin JavaScript Engine** path to
-your custom engines. You can use the editor to customize your engine.
+In addition to using `engine`, you can also customize to <https://github.com/cocos-creator/engine> to clone or fork a copy of the engine to the local anywhere, then uncheck **Use Builtin JavaScript Engine** and set the **Use Builtin JavaScript Engine** path to your custom engines. You can use the editor to customize your engine.
 
 ### Use Builtin Cocos2d-x Engine
 
-Whether to use Cocos Creator the built-in 'cocos2d-x' path as cocos2d-x c++ engine path.
-This engine is used for all **Build** native platform ( iOS, Android, Mac, Windows ) project to build and compile.
+Whether to use Cocos Creator the built-in `cocos2d-x` path as cocos2d-x c++ engine path. This engine is used for all **Build** native platform (iOS, Android, Mac, Windows) project to build and compile.
 
 ### Cocos2d-x Path
 
 **Use Builtin Cocos2d-x Engine** cancel previous selections, you can manually specify the path cocos2d-x.
-Note cocos2d-x engine used here must be downloaded from the https://github.com/cocos-creator/cocos2d-x-lite or the warehouse's fork.
+
+Note cocos2d-x engine used here must be downloaded from the <https://github.com/cocos-creator/engine-native> or the warehouse's fork.
 
 ### NDK Path
 
@@ -102,7 +96,6 @@ Set the Android SDK Path, See [Setup Native Development Environment](../../../pu
 ### ANT Path
 
 Set the ANT Path, See [Setup Native Development Environment](../../../publish/setup-native-development.md).
-
 
 ## Preview Run
 

--- a/en/publish/setup-native-development.md
+++ b/en/publish/setup-native-development.md
@@ -49,7 +49,7 @@ After installing Android Studio, refer to the official documentation and open th
 
 ### Android SDK 10 dependencies
 
-Starting with v1.2.2, the default Android project template will specify the `android-10` sdk platform version as the default target. For more information, see [Pull Request Use API Level 10](https://github.com/cocos-creator/cocos2d-x-lite/pull/316).
+Starting with v1.2.2, the default Android project template will specify the `android-10` sdk platform version as the default target. For more information, see [Pull Request Use API Level 10](https://github.com/cocos-creator/engine-native/pull/316).
 
 If you encounter build error like 'not found android-10', you can download `Android SDK API Level 10` according to the description below.
 

--- a/zh/advanced-topics/engine-customization.md
+++ b/zh/advanced-topics/engine-customization.md
@@ -1,11 +1,11 @@
 # 引擎定制工作流程
 
-Cocos Creator 的引擎部分包括 JavaScript 和 C++ 两个部分。全部都在 github 上开源。地址在：
+Cocos Creator 的引擎部分包括 JavaScript 和 C++ 两个部分。全部都在 GitHub 上开源。地址在：
 
-- Creator-JS 引擎：https://github.com/cocos-creator/engine
-- Cocos2d-x 引擎：https://github.com/cocos-creator/cocos2d-x-lite
+- Creator-JS 引擎：<https://github.com/cocos-creator/engine>
+- Cocos2d-x 引擎：<https://github.com/cocos-creator/engine-native>
 
-我们建议您通过 github 的 fork 工作流程来维护自己定制的仓库，具体操作方式请阅读 [github help: Fork A Repo](https://help.github.com/articles/fork-a-repo)。关于更多 github 相关工作流程请参考 [github help](https://help.github.com)。
+我们建议您通过 GitHub 的 fork 工作流程来维护自己定制的仓库，具体操作方式请阅读 [GitHub help: Fork A Repo](https://help.github.com/articles/fork-a-repo)。关于更多 GitHub 相关工作流程请参考 [GitHub help](https://help.github.com)。
 
 ## 定制 JavaScript 引擎
 
@@ -13,7 +13,7 @@ Cocos Creator 的引擎部分包括 JavaScript 和 C++ 两个部分。全部都�
 
 ### 获取 JS 引擎
 
-首先您需要从 github 上 clone Creator-JS 引擎的原始（地址见上文）或 fork 后的版本。根据不同的 Creator 版本，还需要 checkout 不同的分支，例如 Creator 1.1.2 对应的是引擎的 v1.1 分支。下载后存放到任意本地路径，在命令行中进入此路径。
+首先您需要从 GitHub 上 clone Creator-JS 引擎的原始（地址见上文）或 fork 后的版本。根据不同的 Creator 版本，还需要 checkout 不同的分支，例如 Creator 1.1.2 对应的是引擎的 v1.1 分支。下载后存放到任意本地路径，在命令行中进入此路径。
 
 ### 安装编译依赖
 
@@ -38,11 +38,9 @@ gulp build
 
 通过 **偏好设置** 面板的 [原生开发环境](../getting-started/basics/editor-panels/preferences.md#--8) 分页设置。设置使用您本地定制后的 JS 引擎路径。
 
-
 ## 定制 Cocos2d-x 引擎
 
-
-如果您需要定制渲染和原生接口相关的引擎功能，在修改 JS 引擎的基础上，还需要同步修改 Cocos2d-x 的 C++ 引擎。注意 Cocos Creator 使用的 Cocos2d-x 引擎是专门定制的，需要从上文中指定的 github 仓库下载。
+如果您需要定制渲染和原生接口相关的引擎功能，在修改 JS 引擎的基础上，还需要同步修改 Cocos2d-x 的 C++ 引擎。注意 Cocos Creator 使用的 Cocos2d-x 引擎是专门定制的，需要从上文中指定的 GitHub 仓库下载。
 
 和 JS 引擎类似，C++ 引擎在使用前也请确认当前所在分支，对于 Cocos Creator v1.2.0 版本请使用 `v1.2` 分支。
 
@@ -85,8 +83,7 @@ gulp gen-simulator
 gulp update-simulator-config
 ```
 
-`gulp sign-simulator` 是 1.7.0 中的新增命令，只有 Mac 需要运行。详见 [Build simulator](https://github.com/cocos-creator/cocos2d-x-lite/blob/develop/README.md#git-user-attention)。
-
+`gulp sign-simulator` 是 1.7.0 中的新增命令，只有 Mac 需要运行。详见 [Build simulator](https://github.com/cocos-creator/engine-native/blob/develop/README.md#git-user-attention)。
 
 ### JSB 绑定流程
 

--- a/zh/getting-started/basics/editor-panels/preferences.md
+++ b/zh/getting-started/basics/editor-panels/preferences.md
@@ -70,7 +70,6 @@
 
 和上面的选项类似，这里用来设置在 **资源管理器** 中双击图片文件时，默认打开图片用的应用程序路径。
 
-
 ## 原生开发环境
 
 ![native develop](preferences/native-develop.jpg)
@@ -83,7 +82,7 @@
 
 ### JavaScript 引擎路径
 
-除了使用自带的 `engine`，您也可以前往 https://github.com/cocos-creator/engine 来克隆或 fork 一份引擎到本地的任意位置进行定制，然后取消勾选 **使用内置 JavaScript 引擎**，然后设置 **JavaScript 引擎路径** 到您定制好的引擎路径，就可以在编辑器中使用这份定制后的引擎了。
+除了使用自带的 `engine`，您也可以前往 <https://github.com/cocos-creator/engine> 来克隆或 fork 一份引擎到本地的任意位置进行定制，然后取消勾选 **使用内置 JavaScript 引擎**，然后设置 **JavaScript 引擎路径** 到您定制好的引擎路径，就可以在编辑器中使用这份定制后的引擎了。
 
 ### 使用内置 Cocos2d-x 引擎
 
@@ -91,7 +90,7 @@
 
 ### Cocos2d-x 路径
 
-取消上一项 **使用内置 cocos2d-x 引擎** 的选择后，就可以手动指定 cocos2d-x 路径了。注意这里使用的 cocos2d-x 引擎必须从 https://github.com/cocos-creator/cocos2d-x-lite 或该仓库的 fork 下载。
+取消上一项 **使用内置 Cocos2d-x 引擎** 的选择后，就可以手动指定 Cocos2d-x 路径了。注意这里使用的 Cocos2d-x 引擎必须从 <https://github.com/cocos-creator/engine-native> 或该仓库的 fork 下载。
 
 ### NDK 路径
 
@@ -104,7 +103,6 @@
 ### ANT 路径
 
 设置 ANT 路径，详情见 [安装配置原生开发环境](../../publish/setup-native-development.md)。
-
 
 ## 预览运行
 
@@ -122,7 +120,7 @@
 
 ### 模拟器路径
 
-从 v1.1.0 版开始， Cocos Creator 中使用的 Cocos 模拟器会放置在 cocos2d-x 引擎路径下。在使用定制版引擎时，需要自己编译模拟器到引擎路径下。点击 **打开** 按钮可以在文件系统中打开当前指定的模拟器路径，方便调试时定位。
+从 v1.1.0 版开始， Cocos Creator 中使用的 Cocos 模拟器会放置在 Cocos2d-x 引擎路径下。在使用定制版引擎时，需要自己编译模拟器到引擎路径下。点击 **打开** 按钮可以在文件系统中打开当前指定的模拟器路径，方便调试时定位。
 
 ### 模拟器横竖屏设置
 
@@ -135,4 +133,3 @@
 ### 自定义分辨率设置
 
 如果预设的分辨率不能满足要求，您可以手动输入屏幕宽高来设置模拟器分辨率。
-

--- a/zh/publish/setup-native-development.md
+++ b/zh/publish/setup-native-development.md
@@ -49,7 +49,7 @@ java -version
 
 ### Android SDK 10 依赖
 
-从 v1.2.2 开始，默认的 Android 项目模板将指定 `android-10` sdk platform 版本作为默认的 target，详情可见 [Pull Request Use API Level 10](https://github.com/cocos-creator/cocos2d-x-lite/pull/316)。
+从 v1.2.2 开始，默认的 Android 项目模板将指定 `android-10` sdk platform 版本作为默认的 target，详情可见 [Pull Request Use API Level 10](https://github.com/cocos-creator/engine-native/pull/316)。
 
 如果编译 Android 工程时遇到 '未找到 android-10' 之类的报错，可以通过上文介绍的方式下载 Android SDK API Level 10。
 


### PR DESCRIPTION
本来应该把 JavaScript 引擎替换成 Typescript 引擎的，但是  2d 的面板里还是 JavaScript，防止引起误解，我觉得不改比较好。另外，JavaScript 引擎里面似乎已经没有 v2.4.4 以下版本的分支了？

本来应该把 cocos2d-x 引擎改成 engine-native 引擎，但是 2d 的面板里还是 cocos2d-x，我觉得不改比较好，所以就只是替换了链接。