### PR TITLE
gitignore fix for icloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
 *.rtf
-
+*.icloud
 
 
 npm-debug.log


### PR DESCRIPTION
I use icloud and it tried to version files with a `.icloud` extension and I don't want to accidentally commit any of these. 