### PR TITLE
修正错误关键字，使用导入package.json的方式获取插件名

### DIFF
--- a/en/editor/extension/panel-boot.md
+++ b/en/editor/extension/panel-boot.md
@@ -68,7 +68,7 @@ It is also posible to read a CSS file directly. Example:
 ```javascript
 const {readFileSync} = require('fs');
 const {join} = require('path');
-exports.template = readFileSync(join(__dirname,'../static/default.css'),'utf8');
+exports.style = readFileSync(join(__dirname,'../static/default.css'),'utf8');
 ```
 
 ## $

--- a/en/editor/extension/panel-boot.md
+++ b/en/editor/extension/panel-boot.md
@@ -98,9 +98,10 @@ The method defined on the panel. The external functions of the panel need to be 
 This object is full of functions, do not attach other types of objects here. Example:
 
 ```javascript
+const packageJSON = require('./package.json');
 exports.methods = {
     open() {
-        Editor.Panel.open('hello-world');
+        Editor.Panel.open(packageJSON.name);
     },
 };
 ```

--- a/en/editor/extension/panel-messages.md
+++ b/en/editor/extension/panel-messages.md
@@ -57,9 +57,10 @@ exports.unload = function() {};
 **Last**, define the main file of the panel:
 
 ```javascript
+const packageJSON = require('./package.json');
 exports.ready = async () => {
-    const tab = await Editor.Message.request('hello-world', 'query', 'tab');
-    const subTab = await Editor.Message.request('hello-world', 'query', 'subTab');
+    const tab = await Editor.Message.request(packageJSON.name, 'query', 'tab');
+    const subTab = await Editor.Message.request(packageJSON.name, 'query', 'subTab');
 
     // Print the queried data
     console.log(tab, subTab):
@@ -67,8 +68,8 @@ exports.ready = async () => {
 };
 exports.close() {
     // Upload the data to the extension process after receiving the data
-    Editor.Message.send('hello-world', 'upload', 'tab', 1);
-    Editor.Message.send('hello-world', 'upload', 'subTab', 0);
+    Editor.Message.send(packageJSON.name, 'upload', 'tab', 1);
+    Editor.Message.send(packageJSON.name, 'upload', 'subTab', 0);
 };
 ```
 
@@ -98,8 +99,8 @@ This is because the data has not yet been submitted. Now, close this panel and o
 Because when the panel is closed, two messages are sent:
 
 ```javascript
-Editor.Message.send('hello-world', 'upload', 'tab', 1);
-Editor.Message.send('hello-world', 'upload', 'subTab', 0);
+Editor.Message.send(packageJSON.name, 'upload', 'tab', 1);
+Editor.Message.send(packageJSON.name, 'upload', 'subTab', 0);
 ```
 
 Through these two messages, the Message system first saves the data to the extension process according to the upload definition in messages `"methods": ["saveData"]`.
@@ -107,8 +108,8 @@ Through these two messages, the Message system first saves the data to the exten
 When opening the panel again, use the following code to query for the data you just saved, initialize the interface, and print to the console.
 
 ```javascript
-const tab = await Editor.Message.send('hello-world', 'query', 'tab');
-const subTab = await Editor.Message.send('hello-world', 'query', 'subTab');
+const tab = await Editor.Message.send(packageJSON.name, 'query', 'tab');
+const subTab = await Editor.Message.send(packageJSON.name, 'query', 'subTab');
 ```
 
 At this point, we have completed an interaction between the panel and the extension process.

--- a/en/editor/extension/panel.md
+++ b/en/editor/extension/panel.md
@@ -75,7 +75,7 @@ The panel entry file was defined above when we registered it. Example:
 
 ```javascript
 // Listen for panel events
-exports.linsteners = {
+exports.listeners = {
     // The hook triggered when the panel is displayed
     show() {},
     // The hook triggered when the panel is hidden

--- a/en/editor/extension/profile.md
+++ b/en/editor/extension/profile.md
@@ -94,16 +94,18 @@ Briefly describe this configuration. Where the configuration can be displayed, t
 Read editor configuration
 
 ```javascript
+const packageJSON = require('./package.json');
 // await Editor.Profile.getConfig(pkgName, key, protocol);
-await Editor.Profile.getConfig('hello-world','test.a'); // 0
-await Editor.Profile.getConfig('hello-world','test.a','local'); // undefined
-await Editor.Profile.getConfig('hello-world','test.a','global'); // undefined
+await Editor.Profile.getConfig(packageJSON.name,'test.a'); // 0
+await Editor.Profile.getConfig(packageJSON.name,'test.a','local'); // undefined
+await Editor.Profile.getConfig(packageJSON.name,'test.a','global'); // undefined
 ```
 
 Read project configuration
 
 ```javascript
+const packageJSON = require('./package.json');
 // await Editor.Profile.getConfig(pkgName, key, protocol);
-await Editor.Profile.getProject('hello-world','test.a'); // 1
-await Editor.Profile.getProject('hello-world','test.a','project'); // undefined
+await Editor.Profile.getProject(packageJSON.name,'test.a'); // 1
+await Editor.Profile.getProject(packageJSON.name,'test.a','project'); // undefined
 ```

--- a/zh/editor/extension/panel-boot.md
+++ b/zh/editor/extension/panel-boot.md
@@ -68,7 +68,7 @@ header { padding: 10px; }
 ```javascript
 const { readFileSync } = require('fs');
 const { join } = require('path');
-exports.template = readFileSync(join(__dirname, '../static/default.css'), 'utf8');
+exports.style = readFileSync(join(__dirname, '../static/default.css'), 'utf8');
 ```
 
 ## $
@@ -98,9 +98,10 @@ exports.ready = function() {
 这个对象里都是函数，请不要挂载其他类型的对象到这里。
 
 ```javascript
+const packageJSON = require('./package.json');
 exports.methods = {
     open() {
-        Editor.Panel.open('hello-world');
+        Editor.Panel.open(packageJSON.name);
     },
 };
 ```

--- a/zh/editor/extension/panel-messages.md
+++ b/zh/editor/extension/panel-messages.md
@@ -57,18 +57,18 @@ exports.unload = function() {};
 然后定义面板的 main 文件：
 
 ```javascript
-exports.ready = async () => {
-    const tab = await Editor.Message.request('hello-world', 'query', 'tab');
-    const subTab = await Editor.Message.request('hello-world', 'query', 'subTab');
-
+const packageJSON = require('./package.json');
+exports.ready = async () => {  
+    const tab = await Editor.Message.request(packageJSON.name, 'query', 'tab');
+    const subTab = await Editor.Message.request(packageJSON.name, 'query', 'subTab');
     // 打印查询到的数据
     console.log(tab, subTab):
     // TODO 使用这两个数据初始化
 };
 exports.close() {
     // 收到数据后上传到扩展进程
-    Editor.Message.send('hello-world', 'upload', 'tab', 1);
-    Editor.Message.send('hello-world', 'upload', 'subTab', 0);
+    Editor.Message.send(packageJSON.name, 'upload', 'tab', 1);
+    Editor.Message.send(packageJSON.name, 'upload', 'subTab', 0);
 };
 ```
 
@@ -98,15 +98,15 @@ undefined, undefined
 这是因为面板在关闭的时候，发送了两条消息：
 
 ```javascript
-Editor.Message.send('hello-world', 'upload', 'tab', 1);
-Editor.Message.send('hello-world', 'upload', 'subTab', 0);
+Editor.Message.send(packageJSON.name, 'upload', 'tab', 1);
+Editor.Message.send(packageJSON.name, 'upload', 'subTab', 0);
 ```
 
 通过这两条消息，Message 系统首先根据 messages 里的 upload 定义 `"methods": ["saveData"]`，将数据保存到扩展进程里。当再次打开面板时，通过以下代码查询到刚刚保存的数据，并初始化界面、打印到控制台：
 
 ```javascript
-const tab = await Editor.Message.send('hello-world', 'query', 'tab');
-const subTab = await Editor.Message.send('hello-world', 'query', 'subTab');
+const tab = await Editor.Message.send(packageJSON.name, 'query', 'tab');
+const subTab = await Editor.Message.send(packageJSON.name, 'query', 'subTab');
 ```
 
 至此，我们完成了一次面板与扩展进程的交互。

--- a/zh/editor/extension/panel.md
+++ b/zh/editor/extension/panel.md
@@ -75,7 +75,7 @@ interface PanelSize {
 
 ```javascript
 // 监听面板事件
-exports.linsteners = {
+exports.listeners = {
     // 面板显示的时候触发的钩子
     show() {},
     // 面板隐藏的时候触发的钩子

--- a/zh/editor/extension/profile.md
+++ b/zh/editor/extension/profile.md
@@ -96,18 +96,20 @@ object 的 key 为配置的 key，value 则是描述这个配置的基本信息�
 读取编辑器配置
 
 ```javascript
+const packageJSON = require('./package.json');
 // await Editor.Profile.getConfig(pkgName, key, protocol);
-await Editor.Profile.getConfig('hello-world', 'test.a'); // 0
-await Editor.Profile.getConfig('hello-world', 'test.a', 'local'); // undefined
-await Editor.Profile.getConfig('hello-world', 'test.a', 'global'); // undefined
+await Editor.Profile.getConfig(packageJSON.name, 'test.a'); // 0
+await Editor.Profile.getConfig(packageJSON.name, 'test.a', 'local'); // undefined
+await Editor.Profile.getConfig(packageJSON.name, 'test.a', 'global'); // undefined
 ```
 
 读取项目配置
 
 ```javascript
+const packageJSON = require('./package.json');
 // await Editor.Profile.getConfig(pkgName, key, protocol);
-await Editor.Profile.getProject('hello-world', 'test.a'); // 1
-await Editor.Profile.getProject('hello-world', 'test.a', 'project'); // undefined
+await Editor.Profile.getProject(packageJSON.name, 'test.a'); // 1
+await Editor.Profile.getProject(packageJSON.name, 'test.a', 'project'); // undefined
 ```
 
 ## 配置存放的地方


### PR DESCRIPTION
修正错误关键字
linsteners -> listeners
template ->style (panel-boot.md)

使用导入package.json的方式获取插件名
推荐开发者不要直接写死插件的名称
而是使用 require('./package.json')的方式获取插件的配置
再通过配置获取插件名称
fix https://github.com/cocos-creator/creator-docs/issues/1566