### PR TITLE
fix(doc): 修改 快速上手（2D） 文档中关于 instantiate 的说明

### DIFF
--- a/versions/3.8/zh/getting-started/first-game-2d/index.md
+++ b/versions/3.8/zh/getting-started/first-game-2d/index.md
@@ -758,7 +758,7 @@ export class GameManager extends Component {
 
     通过 `BlockType` 来确定是否要真的创建这个方块，当然只在 `type` 为 `BT_STONE` 的时候我们通过 `instantiate` 方法来创建方块，其他情况下，返回一个空值。
 
-    > `instantiate`: 是 Cocos Creator 提供的克隆预制体的方法。当然它不仅能克隆预制体，你甚至可以用它克隆别的类型比如某个对象！
+    > `instantiate`: 是 Cocos Creator 提供的实例化预制体为节点的方法。当然它不仅能实例化预制体，你甚至可以用它克隆任意类型的对象！
 
 此时如果我们在 `GameManager` 的 `start` 内调用 `generateRoad` 来创建地图：
 


### PR DESCRIPTION
原文中说 instantiate 是用来克隆预制体，这里并不准确，应当是实例化预制体为节点